### PR TITLE
Upgrade Go version in Dockerfile.konflux

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,23 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22@sha256:e66779cc9bef4b5d3361134fda8f054314eef5dc6b356086bae59e65805a57ad AS builder
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.23@sha256:ca0c771ecd4f606986253f747e2773fe2960a6b5e8e7a52f6a4797b173ac7f56
+ AS golang
+
+FROM registry.redhat.io/ubi8/ubi:latest AS builder
+
+ARG GOLANG_VERSION=1.23.0
+
+# Install system dependencies
+RUN dnf upgrade -y && dnf install -y \
+    gcc \
+    make \
+    openssl-devel \
+    git \
+    && dnf clean all && rm -rf /var/cache/yum
+
+# Install Go
+ENV PATH=/usr/local/go/bin:$PATH
+
+COPY --from=golang /usr/lib/golang /usr/local/go
+# End of Go versioning workaround
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-18076 

## Context
Latest version of Kueue (v0.10.0) uses Go version `1.23`. There are many features included in this latest release that require the use of this Go version.

We have several features aimed for RHOAI 2.17, of which can only be supported if we upgrade Kueue's Go version to `1.23`.

## Changes
- This PR uses [the workaround](https://gitlab.cee.redhat.com/data-hub/rhods-cpaas-midstream/-/blob/rhoai-2.15-rhel-8/distgit/containers/odh-codeflare-operator/Dockerfile.in?ref_type=heads#:~:text=%23%20Start%20of%20Go,Go%20versioning%20workaround) that had been previously approved by ProdSec, to use later versions of Go.
- Upgrade Dockerfile.konflux file to use Go `1.23`.



## Tested `Dockerfile.konflux` image:
`quay.io/rh_ee_czaccari/kueue:konfluxlatest`