### PR TITLE
Adjust docker file to use go version 1.23.2

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,7 +1,7 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23@sha256:744be415305e1cf3701484b69e41bd67df2e0b728a5804fa170069cec6c9a189 AS golang
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:e5f5973d201e688987434e3a92d531fa62ec2defa0ff04f51c324b7c82e29dc8 AS golang
 
 FROM registry.redhat.io/ubi8/ubi:latest AS builder
-ARG GOLANG_VERSION=1.23.0
+ARG GOLANG_VERSION=1.23.2
 
 # Install system dependencies
 RUN dnf upgrade -y && dnf install -y \


### PR DESCRIPTION
#### What type of PR is this?
Latest version of brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 is fecthing go lang 1.23.4.
Go lang 1.23.4 requires glibc library version 2.32 or 2.34, however UBI 8 has just glibc 2.28.
As a workaround, using older openshift-golang-builder image version i.e 1.23.2 (which has compatible glibc 2.28)

#### What this PR does / why we need it:
Latest version of brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 is fecthing go lang 1.23.4.
Go lang 1.23.4 requires glibc library version 2.32 or 2.34, however UBI 8 has just glibc 2.28.
As a workaround, using older openshift-golang-builder image version i.e 1.23.2 (which has compatible glibc 2.28)

#### Which issue(s) this PR fixes:
Fix failing kueue build in [rhoai nightly build](https://redhat-internal.slack.com/archives/C07ANR2U56C/p1739338739452249?thread_ts=1739337729.272419&cid=C07ANR2U56C)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None