### PR TITLE
Adjust docker file to use go version 1.23.2

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,7 +1,7 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23@sha256:744be415305e1cf3701484b69e41bd67df2e0b728a5804fa170069cec6c9a189 AS golang
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder@sha256:ca0c771ecd4f606986253f747e2773fe2960a6b5e8e7a52f6a4797b173ac7f56 AS golang
 
 FROM registry.redhat.io/ubi8/ubi:latest AS builder
-ARG GOLANG_VERSION=1.23.0
+ARG GOLANG_VERSION=1.23.2
 
 # Install system dependencies
 RUN dnf upgrade -y && dnf install -y \


### PR DESCRIPTION

#### What type of PR is this?

#### What this PR does / why we need it:
Latest version of brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 is fecthing go lang 1.23.4.
Go lang 1.23.4 requires glibc library version 2.32 or 2.34, however UBI 8 has just glibc 2.28.
As a workaround, using older openshift-golang-builder image version i.e 1.23.2 (which has compatible glibc 2.28)

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None