### PR TITLE
Bump Go version to 1.24.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.24
+ARG BUILDER_IMAGE=golang:1.24.13
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 # Build the manager binary

--- a/Dockerfile.rhoai
+++ b/Dockerfile.rhoai
@@ -4,7 +4,7 @@ FROM ${GOLANG_IMAGE} AS golang
 
 FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
 
-ARG GOLANG_VERSION=1.23.0
+ARG GOLANG_VERSION=1.24.13
 
 # Install system dependencies
 RUN dnf upgrade -y && dnf install -y \

--- a/cmd/experimental/kueue-viz/backend/Dockerfile
+++ b/cmd/experimental/kueue-viz/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG BUILDER_IMAGE=golang:1.23
+ARG BUILDER_IMAGE=golang:1.24.13
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 

--- a/cmd/experimental/kueue-viz/backend/go.mod
+++ b/cmd/experimental/kueue-viz/backend/go.mod
@@ -1,6 +1,6 @@
 module kueue-viz
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/gin-gonic/gin v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kueue
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/cert-manager/cert-manager v1.17.1

--- a/hack/internal/tools/go.mod
+++ b/hack/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kueue/internal/tools
 
-go 1.24.0
+go 1.24.13
 
 require (
 	github.com/gohugoio/hugo v0.145.0


### PR DESCRIPTION
Aligns with downstream Dockerfile.konflux which already uses go 1.24.13.